### PR TITLE
add fragments to remove errors

### DIFF
--- a/rust/v0.1/html/tests/html_tests.rs
+++ b/rust/v0.1/html/tests/html_tests.rs
@@ -1,4 +1,4 @@
-use html::{build, html, HtmlWriter, Injection};
+use html::{build, html, Injection};
 
 const template_str_0: &str = "<hello>world</hello>";
 const template_str_1: &str = "<hello mygood=\"sir\">{}</hello>";
@@ -39,6 +39,7 @@ fn it_works_with_template_injections() {
     );
 
     let finished_template = build(&template1);
+    println!("{}", finished_template);
 }
 
 #[test]
@@ -61,4 +62,5 @@ fn it_works_with_multiple_injections() {
     );
 
     let finished_template = build(&template1);
+    println!("{}", finished_template);
 }

--- a/rust/v0.1/parsley/src/constants.rs
+++ b/rust/v0.1/parsley/src/constants.rs
@@ -22,3 +22,5 @@ pub const NODE: &str = "NODE";
 pub const SPACE: &str = "SPACE";
 pub const TAGNAME: &str = "TAGNAME";
 pub const TEXT: &str = "TEXT";
+pub const FRAGMENT: &str = "FRAGMENT";
+pub const CLOSE_FRAGMENT: &str = "CLOSE_FRAGMENT";

--- a/rust/v0.1/parsley/src/parse.rs
+++ b/rust/v0.1/parsley/src/parse.rs
@@ -8,7 +8,7 @@ use crate::constants::{
 use crate::routes;
 use crate::type_flyweight::{NodeStep, Vector};
 
-pub fn parse_str<'a>(template_str: &'a str) -> Vec<NodeStep> {
+pub fn parse_str<'a>(template_str: &'a str) -> Vec<NodeStep<'a>> {
     let mut steps = Vec::from([NodeStep {
         kind: INITIAL,
         vector: Vector {

--- a/rust/v0.1/parsley/src/routes.rs
+++ b/rust/v0.1/parsley/src/routes.rs
@@ -46,7 +46,7 @@ fn get_state_from_initial<'a>(chr: &char) -> &'a str {
 */
 fn get_state_from_node<'a>(chr: &char) -> &'a str {
     if chr.is_whitespace() {
-        return ERROR;
+        return NODE;
     }
 
     match chr {
@@ -70,7 +70,7 @@ fn get_state_from_tagname<'a>(chr: &char) -> &'a str {
 
 fn get_state_from_close_node_slash<'a>(chr: &char) -> &'a str {
     if chr.is_whitespace() {
-        return ERROR;
+        return CLOSE_NODE_SLASH;
     }
 
     CLOSE_TAGNAME

--- a/rust/v0.1/parsley/src/routes.rs
+++ b/rust/v0.1/parsley/src/routes.rs
@@ -1,8 +1,9 @@
 use crate::constants::{
     ATTRIBUTE, ATTRIBUTE_DECLARATION, ATTRIBUTE_DECLARATION_CLOSE, ATTRIBUTE_MAP_INJECTION,
-    ATTRIBUTE_SETTER, ATTRIBUTE_VALUE, CLOSE_NODE_CLOSED, CLOSE_NODE_SLASH, CLOSE_NODE_SPACE,
-    CLOSE_TAGNAME, DESCENDANT_INJECTION, ERROR, INDEPENDENT_NODE, INDEPENDENT_NODE_CLOSED,
-    INJECTION_CONFIRMED, INJECTION_SPACE, NODE, NODE_CLOSED, NODE_SPACE, TAGNAME, TEXT,
+    ATTRIBUTE_SETTER, ATTRIBUTE_VALUE, CLOSE_FRAGMENT, CLOSE_NODE_CLOSED, CLOSE_NODE_SLASH,
+    CLOSE_NODE_SPACE, CLOSE_TAGNAME, DESCENDANT_INJECTION, ERROR, FRAGMENT, INDEPENDENT_NODE,
+    INDEPENDENT_NODE_CLOSED, INJECTION_CONFIRMED, INJECTION_SPACE, NODE, NODE_CLOSED, NODE_SPACE,
+    TAGNAME, TEXT,
 };
 
 pub fn route<'a>(chr: &char, prev_state: &'a str) -> &'a str {
@@ -35,15 +36,6 @@ fn get_state_from_initial<'a>(chr: &char) -> &'a str {
     }
 }
 
-// dont really need errors? leaves space for syntax like:
-// AND it don't hurt nobody
-/*
-    <
-        hello
-            howdy
-            another-attr
-    >
-*/
 fn get_state_from_node<'a>(chr: &char) -> &'a str {
     if chr.is_whitespace() {
         return NODE;
@@ -51,7 +43,7 @@ fn get_state_from_node<'a>(chr: &char) -> &'a str {
 
     match chr {
         '/' => CLOSE_NODE_SLASH,
-        '>' => ERROR,
+        '>' => FRAGMENT,
         _ => TAGNAME,
     }
 }
@@ -73,7 +65,10 @@ fn get_state_from_close_node_slash<'a>(chr: &char) -> &'a str {
         return CLOSE_NODE_SLASH;
     }
 
-    CLOSE_TAGNAME
+    match chr {
+        '>' => CLOSE_FRAGMENT,
+        _ => CLOSE_TAGNAME,
+    }
 }
 
 fn get_state_from_close_tagname<'a>(chr: &char) -> &'a str {


### PR DESCRIPTION
The parser is very flexible, errors are more necessary downstream when tagnames or attributes are invalid.

Added 'fragment' syntax to remove errors from parser
As in:
`<>` and `</>` will be recognized as `FRAGMENT` and `CLOSE_FRAGMENT`